### PR TITLE
fix: update Note type and remove experimental flag 🔧

### DIFF
--- a/openapi-ts.ts
+++ b/openapi-ts.ts
@@ -1,7 +1,6 @@
 import { createClient } from '@hey-api/openapi-ts'
 
 createClient({
-  experimentalParser: true,
   input: 'https://in.rough.app/api/v1/openapi.json',
   // input: 'http://localhost:5173/api/v1/openapi.json',
   output: 'src/api',

--- a/src/api/types.gen.ts
+++ b/src/api/types.gen.ts
@@ -115,7 +115,7 @@ export type Note = {
   contentId: string
   referenceId?: string
   personId?: string
-  lastModifiedByUserId: string
+  lastModifiedByUserId?: string
   lastModifiedAt: number
 }
 


### PR DESCRIPTION
- Removed experimentalParser flag from openapi-ts config since it's no longer needed
- Updated Note type to make lastModifiedByUserId optional in generated types
- These changes align with the latest API schema updates